### PR TITLE
Use fallback-x11 instead of x11

### DIFF
--- a/org.kde.konversation.json
+++ b/org.kde.konversation.json
@@ -9,7 +9,7 @@
         "--device=dri",
         "--share=ipc",
         "--share=network",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--talk-name=org.kde.kssld5",


### PR DESCRIPTION
This increase security on wayland and prevents showing warning about insecure permissions in app stores