### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.konversation.json
+++ b/org.kde.konversation.json
@@ -18,7 +18,10 @@
     "cleanup": [
         "/include",
         "/lib/cmake",
-        "/lib/pkgconfig"
+        "/lib/pkgconfig",
+        "/share/doc",
+        "/share/man",
+        "/share/qlogging-categories6"
     ],
     "modules": [
         {


### PR DESCRIPTION
The installed size reduced from 12.1 MB to 7.6 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.